### PR TITLE
feat: add chat previews to home page

### DIFF
--- a/src/app/(chat)/chats/_components/chats-loading.tsx
+++ b/src/app/(chat)/chats/_components/chats-loading.tsx
@@ -1,5 +1,5 @@
 import { Skeleton } from '~/components/ui/skeleton';
-import { ChatPreviewLoader } from '../../../_components/chat-preview-loader';
+import { ChatPreviewLoader } from '~/app/_components/chat-preview-loader';
 
 export function ChatsLoading({ count = 9 }: { count?: number }) {
   return (

--- a/src/app/(chat)/chats/_components/chats.tsx
+++ b/src/app/(chat)/chats/_components/chats.tsx
@@ -1,13 +1,6 @@
 import Link from 'next/link';
 import { getChats } from '~/server/db/queries';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '~/components/ui/card';
-import { formatDistanceToNow } from 'date-fns';
+
 import {
   Pagination,
   PaginationContent,
@@ -15,7 +8,7 @@ import {
   PaginationItem,
   PaginationLink,
 } from '~/components/ui/pagination';
-import Image from 'next/image';
+import { ChatPreview } from '~/app/_components/chat-preview';
 
 export default async function Chats({
   offset,
@@ -67,40 +60,7 @@ export default async function Chats({
         <div className="flex flex-col gap-4">
           <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {items.map(chat => (
-              <Link key={chat.id} href={`/chat/${chat.id}`}>
-                <Card className="h-full cursor-pointer transition-shadow hover:shadow-md">
-                  <CardHeader>
-                    <CardTitle className="truncate text-base">
-                      {chat.title}
-                    </CardTitle>
-                    <CardDescription>
-                      Created{' '}
-                      {formatDistanceToNow(chat.createdAt, {
-                        addSuffix: true,
-                      })}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="bg-muted flex aspect-video w-full items-center justify-center overflow-hidden rounded-lg">
-                      {chat.previewImageUrl ? (
-                        <Image
-                          src={chat.previewImageUrl}
-                          alt={chat.title || 'Chat preview'}
-                          width={100}
-                          height={100}
-                          className="h-full w-full object-contain"
-                          unoptimized
-                          sizes="(min-width: 1024px) 33vw, (min-width: 768px) 50vw, 100vw"
-                        />
-                      ) : (
-                        <div className="text-muted-foreground text-sm">
-                          No preview available
-                        </div>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
+              <ChatPreview key={chat.id} chat={chat} />
             ))}
           </div>
           <Pagination>

--- a/src/app/_components/chat-preview.tsx
+++ b/src/app/_components/chat-preview.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card';
+import { formatDistanceToNow } from 'date-fns';
+import type { Chat } from '~/server/db/schema';
+
+export function ChatPreview({ chat }: { chat: Chat }) {
+  return (
+    <Link href={`/chat/${chat.id}`} aria-label={`Open chat "${chat.title}"`}>
+      <Card className="h-full cursor-pointer transition-shadow hover:shadow-md">
+        <CardHeader>
+          <CardTitle className="truncate text-base">{chat.title}</CardTitle>
+          <CardDescription>
+            Created{' '}
+            {formatDistanceToNow(chat.createdAt, {
+              addSuffix: true,
+            })}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-muted relative flex aspect-video w-full items-center justify-center overflow-hidden rounded-lg">
+            {chat.previewImageUrl ? (
+              <Image
+                src={chat.previewImageUrl}
+                alt={chat.title}
+                fill
+                className="object-contain"
+                unoptimized
+              />
+            ) : (
+              <div className="text-muted-foreground text-sm">
+                No preview available
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/app/_components/stats.tsx
+++ b/src/app/_components/stats.tsx
@@ -1,18 +1,11 @@
-import { formatDistanceToNow } from 'date-fns';
 import { BarChart3, MessageCircle, Box, Zap, Clock } from 'lucide-react';
 import {
   getChatAmountForUserThisMonth,
   getChats,
   getDocumentAmountForUser,
 } from '~/server/db/queries';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from '~/components/ui/card';
-import Link from 'next/link';
+import { Card } from '~/components/ui/card';
+import { ChatPreview } from './chat-preview';
 
 export const RECENT_CHATS_LIMIT = 3;
 
@@ -90,28 +83,7 @@ export async function Stats() {
           </h2>
           <div className="grid gap-4 md:grid-cols-3">
             {recentChats.items.map(chat => (
-              <Link key={chat.id} href={`/chat/${chat.id}`}>
-                <Card className="h-full cursor-pointer transition-all duration-200 ease-out hover:shadow-lg">
-                  <CardHeader>
-                    <CardTitle className="truncate text-base">
-                      {chat.title}
-                    </CardTitle>
-                    <CardDescription>
-                      Created{' '}
-                      {formatDistanceToNow(chat.createdAt, {
-                        addSuffix: true,
-                      })}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="bg-muted flex aspect-video w-full items-center justify-center rounded-lg">
-                      <div className="text-muted-foreground text-sm">
-                        Image placeholder
-                      </div>
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
+              <ChatPreview key={chat.id} chat={chat} />
             ))}
           </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consistent, clickable chat preview cards across Chats and Recent Activity.
  * Displays chat titles, relative timestamps, and preview images with a "No preview available" fallback.
  * Responsive layout with hover shadow and improved visual polish.

* **Refactor**
  * Unified per-chat rendering into a shared ChatPreview component for consistency and easier maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->