### PR TITLE
feat: indicate clickability on chat preview

### DIFF
--- a/src/app/_components/chat-preview.tsx
+++ b/src/app/_components/chat-preview.tsx
@@ -9,18 +9,21 @@ import {
 } from '~/components/ui/card';
 import { formatDistanceToNow } from 'date-fns';
 import type { Chat } from '~/server/db/schema';
+import { Clock } from 'lucide-react';
 
 export function ChatPreview({ chat }: { chat: Chat }) {
   return (
     <Link href={`/chat/${chat.id}`} aria-label={`Open chat "${chat.title}"`}>
-      <Card className="h-full cursor-pointer transition-shadow hover:shadow-md">
+      <Card className="hover:border-primary/20 h-full transition-all hover:scale-[1.02] hover:shadow-lg">
         <CardHeader>
           <CardTitle className="truncate text-base">{chat.title}</CardTitle>
           <CardDescription>
-            Created{' '}
-            {formatDistanceToNow(chat.createdAt, {
-              addSuffix: true,
-            })}
+            <div className="flex items-center">
+              <Clock className="mr-1 h-3 w-3" />
+              {formatDistanceToNow(chat.createdAt, {
+                addSuffix: true,
+              })}
+            </div>
           </CardDescription>
         </CardHeader>
         <CardContent>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Chat preview now shows a clock icon next to the creation time for clearer context.
  * Card hover behavior updated: subtle border highlight, gentle scale-up, stronger shadow, and smoother transitions.
  * Timestamp and icon alignment improved for readability.
  * “No preview available” state refined with hover-driven color and text transitions.
  * Visual-only update; no functional or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->